### PR TITLE
fix: correct error wrapping (%s→%w) and typos across SDK

### DIFF
--- a/incoming_payment.go
+++ b/incoming_payment.go
@@ -86,7 +86,7 @@ func getPublic(ctx context.Context, doUnsigned RequestDoer, url string) (rs.Publ
 	var incomingPayment rs.PublicIncomingPayment
 	err = json.NewDecoder(resp.Body).Decode(&incomingPayment)
 	if err != nil {
-		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return incomingPayment, nil
@@ -113,7 +113,7 @@ func (ip *IncomingPaymentService) Get(ctx context.Context, params IncomingPaymen
 	var incomingPayment rs.IncomingPaymentWithMethods
 	err = json.NewDecoder(resp.Body).Decode(&incomingPayment)
 	if err != nil {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return incomingPayment, nil
@@ -155,13 +155,13 @@ func (ip *IncomingPaymentService) List(ctx context.Context, params IncomingPayme
 	var listResponse IncomingPaymentListResponse
 	err = json.NewDecoder(resp.Body).Decode(&listResponse)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode response body: %s", err)
+		return nil, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return &listResponse, nil
 }
 
-// TODO: should Create handle adding /incoming-paymnets or nah? php and rust do, ts doesnt
+// TODO: should Create handle adding /incoming-payments or nah? php and rust do, ts doesnt
 func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPaymentCreateParams) (rs.IncomingPaymentWithMethods, error) {
 	payloadBytes, err := json.Marshal(params.Payload)
 	if err != nil {
@@ -176,7 +176,7 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 		return rs.IncomingPaymentWithMethods{}, err
 	}
 
-	// TODO: do this more centrally? in DoSigned when content-legnth > 0?
+	// TODO: do this more centrally? in DoSigned when content-length > 0?
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("GNAP %s", params.AccessToken))
 
@@ -193,7 +193,7 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 	var incomingPayment rs.IncomingPaymentWithMethods
 	err = json.NewDecoder(resp.Body).Decode(&incomingPayment)
 	if err != nil {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return incomingPayment, nil

--- a/quote.go
+++ b/quote.go
@@ -50,7 +50,7 @@ func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 	var quote rs.Quote
 	err = json.NewDecoder(resp.Body).Decode(&quote)
 	if err != nil {
-		return rs.Quote{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.Quote{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return quote, nil
@@ -86,7 +86,7 @@ func (ip *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (r
 	var quote rs.Quote
 	err = json.NewDecoder(resp.Body).Decode(&quote)
 	if err != nil {
-		return rs.Quote{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.Quote{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return quote, nil

--- a/wallet_address.go
+++ b/wallet_address.go
@@ -43,7 +43,7 @@ func (wa *WalletAddressService) Get(ctx context.Context, params WalletAddressGet
 	var walletAddressResponse was.WalletAddress
 	err = json.NewDecoder(resp.Body).Decode(&walletAddressResponse)
 	if err != nil {
-		return was.WalletAddress{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.WalletAddress{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return walletAddressResponse, nil
@@ -70,7 +70,7 @@ func (wa *WalletAddressService) GetKeys(ctx context.Context, params WalletAddres
 	var keyResponse was.JsonWebKeySet
 	err = json.NewDecoder(resp.Body).Decode(&keyResponse)
 	if err != nil {
-		return was.JsonWebKeySet{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.JsonWebKeySet{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return keyResponse, nil
@@ -97,7 +97,7 @@ func (wa *WalletAddressService) GetDIDDocument(ctx context.Context, params Walle
 	var DIDDocumentResponse was.DidDocument
 	err = json.NewDecoder(resp.Body).Decode(&DIDDocumentResponse)
 	if err != nil {
-		return was.DidDocument{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.DidDocument{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return DIDDocumentResponse, nil


### PR DESCRIPTION
## Summary

Two categories of fixes:

### 1. Error wrapping: `%s` → `%w`
Several `fmt.Errorf` calls used `%s` instead of `%w` for error arguments, which breaks `errors.Is()` and `errors.As()` unwrapping. The newer files (`outgoing_payment.go`, `grant.go`) already use `%w` correctly — this brings the older files in line.

**Files:** `incoming_payment.go` (4 sites), `quote.go` (2 sites), `wallet_address.go` (3 sites)

### 2. Typos
- `wallet_address.go`: "failed to decoding" → "failed to decode" (3 occurrences)
- `incoming_payment.go`: "paymnets" → "payments", "legnth" → "length" in TODO comments