### PR TITLE
fix: use OpError for token and grant HTTP error responses

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,87 @@
+package openpayments
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// OpError represents an error from the Open Payments API.
+// It preserves the HTTP status code and any structured error
+// details from the response body, enabling callers to
+// programmatically handle different error scenarios.
+type OpError struct {
+	// StatusCode is the HTTP status code (e.g., 401, 403, 404).
+	StatusCode int
+
+	// Status is the HTTP status text (e.g., "401 Unauthorized").
+	Status string
+
+	// Message is a human-readable error description.
+	Message string
+
+	// Details contains any structured error information from the
+	// response body, if the server returned JSON.
+	Details map[string]interface{}
+}
+
+func (e *OpError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s: %s", e.Status, e.Message)
+	}
+	return e.Status
+}
+
+// IsStatus returns true if the error has the given HTTP status code.
+func (e *OpError) IsStatus(code int) bool {
+	return e.StatusCode == code
+}
+
+// IsUnauthorized returns true if the error is a 401 Unauthorized response.
+func (e *OpError) IsUnauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized
+}
+
+// IsForbidden returns true if the error is a 403 Forbidden response.
+func (e *OpError) IsForbidden() bool {
+	return e.StatusCode == http.StatusForbidden
+}
+
+// IsNotFound returns true if the error is a 404 Not Found response.
+func (e *OpError) IsNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}
+
+// newOpError creates an OpError from an HTTP response.
+// It reads and attempts to parse the response body as JSON
+// for structured error details.
+func newOpError(resp *http.Response, operation string) *OpError {
+	opErr := &OpError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Message:    fmt.Sprintf("failed to %s", operation),
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || len(body) == 0 {
+		return opErr
+	}
+
+	// Try to parse the response body as JSON for structured details
+	var details map[string]interface{}
+	if json.Unmarshal(body, &details) == nil {
+		opErr.Details = details
+		// If the server sent a description, use it as the message
+		if desc, ok := details["description"].(string); ok {
+			opErr.Message = desc
+		} else if msg, ok := details["message"].(string); ok {
+			opErr.Message = msg
+		}
+	} else {
+		// Body wasn't JSON — include it as-is in the message
+		opErr.Message = fmt.Sprintf("failed to %s: %s", operation, string(body))
+	}
+
+	return opErr
+}

--- a/grant.go
+++ b/grant.go
@@ -134,7 +134,7 @@ func (gs *GrantService) Continue(ctx context.Context, params GrantContinueParams
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return Grant{}, fmt.Errorf("continue request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return Grant{}, newOpError(resp, "continue grant")
 	}
 
 	var grantResponse Grant
@@ -163,7 +163,7 @@ func (gs *GrantService) Cancel(ctx context.Context, params GrantCancelParams) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("cancel request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return newOpError(resp, "cancel grant")
 	}
 
 	return nil

--- a/incoming_payment.go
+++ b/incoming_payment.go
@@ -80,7 +80,7 @@ func getPublic(ctx context.Context, doUnsigned RequestDoer, url string) (rs.Publ
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.PublicIncomingPayment{}, newOpError(resp, "get public incoming payment")
 	}
 
 	var incomingPayment rs.PublicIncomingPayment
@@ -107,7 +107,7 @@ func (ip *IncomingPaymentService) Get(ctx context.Context, params IncomingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "get incoming payment")
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
@@ -149,7 +149,7 @@ func (ip *IncomingPaymentService) List(ctx context.Context, params IncomingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return nil, newOpError(resp, "list incoming payments")
 	}
 
 	var listResponse IncomingPaymentListResponse
@@ -187,7 +187,7 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to create incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "create incoming payment")
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
@@ -216,7 +216,7 @@ func (ip *IncomingPaymentService) Complete(ctx context.Context, params IncomingP
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to complete incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "complete incoming payment")
 	}
 
 	// TODO: add the validation like TS? php/rust. Not sure if we should on principle.

--- a/outgoing_payment.go
+++ b/outgoing_payment.go
@@ -61,7 +61,7 @@ func (op *OutgoingPaymentService) Get(ctx context.Context, params OutgoingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to get outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newOpError(resp, "get outgoing payment")
 	}
 
 	var outgoingPayment rs.OutgoingPayment
@@ -107,7 +107,7 @@ func (op *OutgoingPaymentService) List(ctx context.Context, params OutgoingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list outgoing payments: %s", resp.Status)
+		return nil, newOpError(resp, "list outgoing payments")
 	}
 
 	var listResponse OutgoingPaymentListResponse
@@ -148,7 +148,7 @@ func (op *OutgoingPaymentService) Create(ctx context.Context, params OutgoingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to create outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newOpError(resp, "create outgoing payment")
 	}
 
 	var outgoingPayment rs.OutgoingPayment

--- a/quote.go
+++ b/quote.go
@@ -44,7 +44,7 @@ func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.Quote{}, fmt.Errorf("failed to get quote: %s", resp.Status)
+		return rs.Quote{}, newOpError(resp, "get quote")
 	}
 
 	var quote rs.Quote
@@ -80,7 +80,7 @@ func (ip *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (r
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.Quote{}, fmt.Errorf("failed to create quote: %s", resp.Status)
+		return rs.Quote{}, newOpError(resp, "create quote")
 	}
 
 	var quote rs.Quote

--- a/token.go
+++ b/token.go
@@ -46,7 +46,7 @@ func (ts *TokenService) Rotate(ctx context.Context, params TokenRotateParams) (a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as.AccessToken{}, fmt.Errorf("rotate request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return as.AccessToken{}, newOpError(resp, "rotate token")
 	}
 
 	var response struct {
@@ -78,7 +78,7 @@ func (ts *TokenService) Revoke(ctx context.Context, params TokenRevokeParams) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("revoke request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return newOpError(resp, "revoke token")
 	}
 
 	return nil

--- a/wallet_address.go
+++ b/wallet_address.go
@@ -37,7 +37,7 @@ func (wa *WalletAddressService) Get(ctx context.Context, params WalletAddressGet
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.WalletAddress{}, fmt.Errorf("failed to get wallet address: %s", resp.Status)
+		return was.WalletAddress{}, newOpError(resp, "get wallet address")
 	}
 
 	var walletAddressResponse was.WalletAddress
@@ -64,7 +64,7 @@ func (wa *WalletAddressService) GetKeys(ctx context.Context, params WalletAddres
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.JsonWebKeySet{}, fmt.Errorf("failed to get json web keys: %s", resp.Status)
+		return was.JsonWebKeySet{}, newOpError(resp, "get wallet address keys")
 	}
 
 	var keyResponse was.JsonWebKeySet
@@ -91,7 +91,7 @@ func (wa *WalletAddressService) GetDIDDocument(ctx context.Context, params Walle
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.DidDocument{}, fmt.Errorf("failed to get DID document: %s", resp.Status)
+		return was.DidDocument{}, newOpError(resp, "get DID document")
 	}
 
 	var DIDDocumentResponse was.DidDocument


### PR DESCRIPTION
## Summary

Follow-up to #39 — applies the `OpError` type to the remaining service files that still used `fmt.Errorf` for HTTP status errors:

- `token.go`: Rotate and Revoke status checks
- `grant.go`: Continue and Cancel status checks

After this + #39, all HTTP API errors across the SDK are consistently typed.

**Depends on:** #39