### PR TITLE
test: add unit tests for OpError type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,87 @@
+package openpayments
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// OpError represents an error from the Open Payments API.
+// It preserves the HTTP status code and any structured error
+// details from the response body, enabling callers to
+// programmatically handle different error scenarios.
+type OpError struct {
+	// StatusCode is the HTTP status code (e.g., 401, 403, 404).
+	StatusCode int
+
+	// Status is the HTTP status text (e.g., "401 Unauthorized").
+	Status string
+
+	// Message is a human-readable error description.
+	Message string
+
+	// Details contains any structured error information from the
+	// response body, if the server returned JSON.
+	Details map[string]interface{}
+}
+
+func (e *OpError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s: %s", e.Status, e.Message)
+	}
+	return e.Status
+}
+
+// IsStatus returns true if the error has the given HTTP status code.
+func (e *OpError) IsStatus(code int) bool {
+	return e.StatusCode == code
+}
+
+// IsUnauthorized returns true if the error is a 401 Unauthorized response.
+func (e *OpError) IsUnauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized
+}
+
+// IsForbidden returns true if the error is a 403 Forbidden response.
+func (e *OpError) IsForbidden() bool {
+	return e.StatusCode == http.StatusForbidden
+}
+
+// IsNotFound returns true if the error is a 404 Not Found response.
+func (e *OpError) IsNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}
+
+// newOpError creates an OpError from an HTTP response.
+// It reads and attempts to parse the response body as JSON
+// for structured error details.
+func newOpError(resp *http.Response, operation string) *OpError {
+	opErr := &OpError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Message:    fmt.Sprintf("failed to %s", operation),
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || len(body) == 0 {
+		return opErr
+	}
+
+	// Try to parse the response body as JSON for structured details
+	var details map[string]interface{}
+	if json.Unmarshal(body, &details) == nil {
+		opErr.Details = details
+		// If the server sent a description, use it as the message
+		if desc, ok := details["description"].(string); ok {
+			opErr.Message = desc
+		} else if msg, ok := details["message"].(string); ok {
+			opErr.Message = msg
+		}
+	} else {
+		// Body wasn't JSON — include it as-is in the message
+		opErr.Message = fmt.Sprintf("failed to %s: %s", operation, string(body))
+	}
+
+	return opErr
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,96 @@
+package openpayments
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func newTestResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestOpErrorBasic(t *testing.T) {
+	resp := newTestResponse(404, "")
+	err := newOpError(resp, "get incoming payment")
+
+	if err.StatusCode != 404 {
+		t.Errorf("expected status code 404, got %d", err.StatusCode)
+	}
+	if !err.IsNotFound() {
+		t.Error("expected IsNotFound to be true")
+	}
+	if err.IsUnauthorized() {
+		t.Error("expected IsUnauthorized to be false")
+	}
+}
+
+func TestOpErrorWithJSONBody(t *testing.T) {
+	body := `{"code":"invalid_token","description":"The access token is expired"}`
+	resp := newTestResponse(401, body)
+	err := newOpError(resp, "get outgoing payment")
+
+	if err.StatusCode != 401 {
+		t.Errorf("expected status code 401, got %d", err.StatusCode)
+	}
+	if !err.IsUnauthorized() {
+		t.Error("expected IsUnauthorized to be true")
+	}
+	// Should use the "description" field from the JSON body
+	if err.Message != "The access token is expired" {
+		t.Errorf("expected message from JSON body, got: %s", err.Message)
+	}
+	if err.Details == nil {
+		t.Fatal("expected details to be populated")
+	}
+	if err.Details["code"] != "invalid_token" {
+		t.Errorf("expected code=invalid_token, got: %v", err.Details["code"])
+	}
+}
+
+func TestOpErrorWithPlainTextBody(t *testing.T) {
+	resp := newTestResponse(500, "Internal Server Error occurred")
+	err := newOpError(resp, "create quote")
+
+	if err.StatusCode != 500 {
+		t.Errorf("expected status code 500, got %d", err.StatusCode)
+	}
+	if err.Details != nil {
+		t.Error("expected no details for plain text body")
+	}
+	if !strings.Contains(err.Message, "Internal Server Error occurred") {
+		t.Errorf("expected message to contain body text, got: %s", err.Message)
+	}
+}
+
+func TestOpErrorImplementsError(t *testing.T) {
+	resp := newTestResponse(403, "")
+	err := newOpError(resp, "list payments")
+
+	// Should be usable as a regular error
+	var opErr *OpError
+	if !errors.As(err, &opErr) {
+		t.Error("expected errors.As to match *OpError")
+	}
+	if !opErr.IsForbidden() {
+		t.Error("expected IsForbidden to be true")
+	}
+}
+
+func TestOpErrorIsStatus(t *testing.T) {
+	resp := newTestResponse(429, "")
+	err := newOpError(resp, "create payment")
+
+	if !err.IsStatus(429) {
+		t.Error("expected IsStatus(429) to be true")
+	}
+	if err.IsStatus(200) {
+		t.Error("expected IsStatus(200) to be false")
+	}
+}

--- a/incoming_payment.go
+++ b/incoming_payment.go
@@ -80,7 +80,7 @@ func getPublic(ctx context.Context, doUnsigned RequestDoer, url string) (rs.Publ
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.PublicIncomingPayment{}, newOpError(resp, "get public incoming payment")
 	}
 
 	var incomingPayment rs.PublicIncomingPayment
@@ -107,7 +107,7 @@ func (ip *IncomingPaymentService) Get(ctx context.Context, params IncomingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "get incoming payment")
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
@@ -149,7 +149,7 @@ func (ip *IncomingPaymentService) List(ctx context.Context, params IncomingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return nil, newOpError(resp, "list incoming payments")
 	}
 
 	var listResponse IncomingPaymentListResponse
@@ -187,7 +187,7 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to create incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "create incoming payment")
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
@@ -216,7 +216,7 @@ func (ip *IncomingPaymentService) Complete(ctx context.Context, params IncomingP
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to complete incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newOpError(resp, "complete incoming payment")
 	}
 
 	// TODO: add the validation like TS? php/rust. Not sure if we should on principle.

--- a/outgoing_payment.go
+++ b/outgoing_payment.go
@@ -61,7 +61,7 @@ func (op *OutgoingPaymentService) Get(ctx context.Context, params OutgoingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to get outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newOpError(resp, "get outgoing payment")
 	}
 
 	var outgoingPayment rs.OutgoingPayment
@@ -107,7 +107,7 @@ func (op *OutgoingPaymentService) List(ctx context.Context, params OutgoingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list outgoing payments: %s", resp.Status)
+		return nil, newOpError(resp, "list outgoing payments")
 	}
 
 	var listResponse OutgoingPaymentListResponse
@@ -148,7 +148,7 @@ func (op *OutgoingPaymentService) Create(ctx context.Context, params OutgoingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to create outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newOpError(resp, "create outgoing payment")
 	}
 
 	var outgoingPayment rs.OutgoingPayment

--- a/quote.go
+++ b/quote.go
@@ -44,7 +44,7 @@ func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.Quote{}, fmt.Errorf("failed to get quote: %s", resp.Status)
+		return rs.Quote{}, newOpError(resp, "get quote")
 	}
 
 	var quote rs.Quote
@@ -80,7 +80,7 @@ func (ip *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (r
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.Quote{}, fmt.Errorf("failed to create quote: %s", resp.Status)
+		return rs.Quote{}, newOpError(resp, "create quote")
 	}
 
 	var quote rs.Quote

--- a/wallet_address.go
+++ b/wallet_address.go
@@ -37,7 +37,7 @@ func (wa *WalletAddressService) Get(ctx context.Context, params WalletAddressGet
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.WalletAddress{}, fmt.Errorf("failed to get wallet address: %s", resp.Status)
+		return was.WalletAddress{}, newOpError(resp, "get wallet address")
 	}
 
 	var walletAddressResponse was.WalletAddress
@@ -64,7 +64,7 @@ func (wa *WalletAddressService) GetKeys(ctx context.Context, params WalletAddres
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.JsonWebKeySet{}, fmt.Errorf("failed to get json web keys: %s", resp.Status)
+		return was.JsonWebKeySet{}, newOpError(resp, "get wallet address keys")
 	}
 
 	var keyResponse was.JsonWebKeySet
@@ -91,7 +91,7 @@ func (wa *WalletAddressService) GetDIDDocument(ctx context.Context, params Walle
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.DidDocument{}, fmt.Errorf("failed to get DID document: %s", resp.Status)
+		return was.DidDocument{}, newOpError(resp, "get DID document")
 	}
 
 	var DIDDocumentResponse was.DidDocument


### PR DESCRIPTION
## Summary

Adds 5 unit tests for the `OpError` structured error type introduced in #39:

| Test | What it verifies |
|------|------------------|
| `TestOpErrorBasic` | Status code, IsNotFound/IsUnauthorized |
| `TestOpErrorWithJSONBody` | JSON body parsing → Details map + message extraction |
| `TestOpErrorWithPlainTextBody` | Plain text body included in message |
| `TestOpErrorImplementsError` | `errors.As` compatibility for type switching |
| `TestOpErrorIsStatus` | Custom status code matching (e.g., 429) |

**Depends on:** #39

## Test plan
- [x] `go test . -v -run TestOpError` — all 5 pass