### PR TITLE
refactor: cleanup url & header formation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Set up Go v1.24
+      - name: Set up Go v1.26
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -51,10 +51,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.21"
-          - "1.22"
-          - "1.23"
-          - "1.24"
+          - "1.26"
     name: "Build and test: go v${{ matrix.go }}"
     steps:
       - name: Checkout source code
@@ -91,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: "1.26"
 
       - name: Verify Go version
         run: go version
@@ -125,7 +122,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           check-latest: true
 
       - name: Configure Git

--- a/client.go
+++ b/client.go
@@ -173,5 +173,5 @@ func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error
 		c.postSignHook(req)
 	}
 
-	return c.httpClient.Do(req)
+	return c.httpClient.Do(req) // #nosec G704 -- client SDK: request URLs are supplied by the library consumer
 }

--- a/client.go
+++ b/client.go
@@ -158,11 +158,16 @@ func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+		contentLen := len(bodyBytes)
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", contentLen))
 
 		contentDigest := createContentDigest(bodyBytes)
 
 		req.Header.Set("Content-Digest", contentDigest)
+
+		if contentLen > 0 {
+			req.Header.Set("Content-Type", "application/json")
+		}
 	}
 
 	sigHeaders, err := httpsignatureutils.CreateSignatureHeaders(httpsignatureutils.SignOptions{

--- a/client.go
+++ b/client.go
@@ -3,8 +3,6 @@ package openpayments
 import (
 	"bytes"
 	"crypto/ed25519"
-	"crypto/sha512"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -136,13 +134,6 @@ func NewAuthenticatedClient(walletAddressUrl string, privateKey string, keyId st
 	return c, nil
 }
 
-func createContentDigest(body []byte) string {
-	hash := sha512.Sum512(body)
-	b64Hash := base64.StdEncoding.EncodeToString(hash[:])
-	digest := fmt.Sprintf("sha-512=:%s:", b64Hash)
-	return digest
-}
-
 func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error) {
 	if c.preSignHook != nil {
 		c.preSignHook(req)
@@ -158,15 +149,11 @@ func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-		contentLen := len(bodyBytes)
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", contentLen))
-
-		contentDigest := createContentDigest(bodyBytes)
-
-		req.Header.Set("Content-Digest", contentDigest)
-
-		if contentLen > 0 {
-			req.Header.Set("Content-Type", "application/json")
+		if len(bodyBytes) > 0 {
+			contentHeaders := httpsignatureutils.CreateContentHeaders(bodyBytes)
+			req.Header.Set("Content-Digest", contentHeaders.ContentDigest)
+			req.Header.Set("Content-Length", contentHeaders.ContentLength)
+			req.Header.Set("Content-Type", contentHeaders.ContentType)
 		}
 	}
 
@@ -188,27 +175,3 @@ func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error
 
 	return c.httpClient.Do(req)
 }
-
-// TODO: use or lose this DoSigned implementation. Did not like the (more or less) necessary side effect
-// of CreateHeaders mutating the request. CreateHeaders has to add the content digest/length before signing.
-// Could clone req in CreateHeaders but that seemed a bit heavy and potentially complicated. Alternatively
-// could maybe just rename? SetSignatureHeaders? Just feels like maybe thats doing too much in httpsignatureutils.
-
-// func (c *AuthenticatedClient) DoSigned(req *http.Request) (*http.Response, error) {
-// 	headers, err := httpsignatureutils.CreateHeaders(httpsignatureutils.SignOptions{
-// 		Request:    req,
-// 		PrivateKey: c.privateKey,
-// 		KeyID:      c.keyId,
-// 	})
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	// This aren't actually necessary to set because CreateHeaders does it.
-// 	// req.Header.Set("Content-Length", headers.ContentLength)
-// 	// req.Header.Set("Content-Digest", headers.ContentDigest)
-// 	req.Header.Set("Signature", fmt.Sprintf("sig1=:%s:", headers.Signature))
-// 	req.Header.Set("Signature-Input", headers.SignatureInput)
-
-// 	return c.httpClient.Do(req)
-// }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/interledger/open-payments-go
 
 go 1.22.5
 
-toolchain go1.24.4
+toolchain go1.26.3
 
 require (
 	github.com/go-rod/rod v0.116.2

--- a/grant.go
+++ b/grant.go
@@ -74,7 +74,6 @@ func (gs *GrantService) Request(ctx context.Context, params GrantRequestParams) 
 	if err != nil {
 		return Grant{}, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := gs.DoSigned(req)
 	if err != nil {
@@ -111,7 +110,7 @@ func (gs *GrantService) Continue(ctx context.Context, params GrantContinueParams
 
 	requestBody := map[string]string{}
 
-	if (params.InteractRef != "") {
+	if params.InteractRef != "" {
 		requestBody["interact_ref"] = params.InteractRef
 	}
 
@@ -124,7 +123,7 @@ func (gs *GrantService) Continue(ctx context.Context, params GrantContinueParams
 	if err != nil {
 		return Grant{}, fmt.Errorf("failed to create continue request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+
 	req.Header.Set("Authorization", "GNAP "+params.AccessToken)
 
 	resp, err := gs.DoSigned(req)

--- a/httpsignatureutils/integration_test.go
+++ b/httpsignatureutils/integration_test.go
@@ -39,19 +39,19 @@ func TestCreateAndValidateSignature(t *testing.T) {
 		t.Fatalf("signature validation failed: %v", err)
 	}
 
-		// negative test - bad signature should fail
-		t.Run("InvalidSignature", func(t *testing.T) {
-			// flip bits of first byte
-			badSig := []byte(sigHeaders.Signature)
-			badSig[0] ^= 0xFF
-	
-			req.Header.Set("Signature", string(badSig))
-	
-			err = ValidateSignature(
-				NewValidationOptions(req, req.Header, publicKey),
-			)
-			if err == nil {
-				t.Fatal("expected validation to fail with bad signature, but it passed")
-			}
-		})
+	// negative test - bad signature should fail
+	t.Run("InvalidSignature", func(t *testing.T) {
+		// flip bits of first byte
+		badSig := []byte(sigHeaders.Signature)
+		badSig[0] ^= 0xFF
+
+		req.Header.Set("Signature", string(badSig))
+
+		err = ValidateSignature(
+			NewValidationOptions(req, req.Header, publicKey),
+		)
+		if err == nil {
+			t.Fatal("expected validation to fail with bad signature, but it passed")
+		}
+	})
 }

--- a/httpsignatureutils/integration_test.go
+++ b/httpsignatureutils/integration_test.go
@@ -18,9 +18,9 @@ func TestCreateAndValidateSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
 
-	sigHeaders, err := CreateHeaders(SignOptions{
+	contentHeaders := CreateContentHeaders(body.Bytes())
+	sigHeaders, err := CreateSignatureHeaders(SignOptions{
 		Request:    req,
 		PrivateKey: privateKey,
 		KeyID:      "test-key",
@@ -29,6 +29,9 @@ func TestCreateAndValidateSignature(t *testing.T) {
 		t.Fatalf("failed to sign request: %v", err)
 	}
 
+	req.Header.Set("Content-Digest", contentHeaders.ContentDigest)
+	req.Header.Set("Content-Length", contentHeaders.ContentLength)
+	req.Header.Set("Content-Type", contentHeaders.ContentType)
 	req.Header.Set("Signature", sigHeaders.Signature)
 	req.Header.Set("Signature-Input", sigHeaders.SignatureInput)
 

--- a/httpsignatureutils/signature.go
+++ b/httpsignatureutils/signature.go
@@ -133,12 +133,13 @@ func CreateHeaders(opts SignOptions) (*ContentAndSignatureHeaders, error) {
 			return nil, fmt.Errorf("failed to close request body: %w", err)
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 
+	contentLen := len(bodyBytes)
 	if len(bodyBytes) > 0 {
 		req.Header.Set("Content-Digest", createContentDigest(bodyBytes))
 		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", contentLen))
 	}
 
 	sigHeaders, err := CreateSignatureHeaders(opts)

--- a/httpsignatureutils/signature.go
+++ b/httpsignatureutils/signature.go
@@ -1,14 +1,13 @@
 package httpsignatureutils
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"crypto/sha512"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -17,11 +16,10 @@ var (
 	ErrMissingRequiredHeader = errors.New("missing required header")
 )
 
-type ContentAndSignatureHeaders struct {
-	Signature      string
-	SignatureInput string
-	ContentDigest  string
-	ContentLength  string
+type ContentHeaders struct {
+	ContentDigest string
+	ContentLength string
+	ContentType   string
 }
 
 type SignatureHeaders struct {
@@ -33,6 +31,21 @@ type SignOptions struct {
 	Request    *http.Request
 	PrivateKey ed25519.PrivateKey
 	KeyID      string
+}
+
+func createContentDigest(body []byte) string {
+	hash := sha512.Sum512(body)
+	b64Hash := base64.StdEncoding.EncodeToString(hash[:])
+	digest := fmt.Sprintf("sha-512=:%s:", b64Hash)
+	return digest
+}
+
+func CreateContentHeaders(body []byte) ContentHeaders {
+	return ContentHeaders{
+		ContentDigest: createContentDigest(body),
+		ContentLength: strconv.Itoa(len(body)),
+		ContentType:   "application/json",
+	}
 }
 
 func createSignatureBaseString(req *http.Request, components []string, created int64, keyID string) (string, error) {
@@ -110,47 +123,5 @@ func CreateSignatureHeaders(opts SignOptions) (*SignatureHeaders, error) {
 	return &SignatureHeaders{
 		Signature:      signature,
 		SignatureInput: signatureInput,
-	}, nil
-}
-
-func createContentDigest(body []byte) string {
-	hash := sha512.Sum512(body)
-	b64Hash := base64.StdEncoding.EncodeToString(hash[:])
-	digest := fmt.Sprintf("sha-512=:%s:", b64Hash)
-	return digest
-}
-
-func CreateHeaders(opts SignOptions) (*ContentAndSignatureHeaders, error) {
-	req := opts.Request
-	var bodyBytes []byte
-	if req.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		if err := req.Body.Close(); err != nil {
-			return nil, fmt.Errorf("failed to close request body: %w", err)
-		}
-		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-	}
-
-	contentLen := len(bodyBytes)
-	if len(bodyBytes) > 0 {
-		req.Header.Set("Content-Digest", createContentDigest(bodyBytes))
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", contentLen))
-	}
-
-	sigHeaders, err := CreateSignatureHeaders(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ContentAndSignatureHeaders{
-		Signature:      sigHeaders.Signature,
-		SignatureInput: sigHeaders.SignatureInput,
-		ContentDigest:  req.Header.Get("Content-Digest"),
-		ContentLength:  req.Header.Get("Content-Length"),
 	}, nil
 }

--- a/incoming_payment.go
+++ b/incoming_payment.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	rs "github.com/interledger/open-payments-go/generated/resourceserver"
 )
@@ -132,8 +131,11 @@ func (ip *IncomingPaymentService) List(ctx context.Context, params IncomingPayme
 		query.Set("cursor", params.Pagination.Cursor)
 	}
 
-	base := strings.TrimRight(params.BaseURL, "/")
-	fullURL := fmt.Sprintf("%s/incoming-payments?%s", base, query.Encode())
+	base, err := url.JoinPath(params.BaseURL, "incoming-payments")
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct URL: %w", err)
+	}
+	fullURL := fmt.Sprintf("%s?%s", base, query.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
 	if err != nil {
@@ -168,16 +170,16 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	baseURL := strings.TrimRight(params.BaseURL, "/")
-	fullURL := fmt.Sprintf("%s/incoming-payments", baseURL)
+	fullURL, err := url.JoinPath(params.BaseURL, "incoming-payments")
+	if err != nil {
+		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to construct URL: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return rs.IncomingPaymentWithMethods{}, err
 	}
 
-	// TODO: do this more centrally? in DoSigned when content-legnth > 0?
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("GNAP %s", params.AccessToken))
 
 	resp, err := ip.DoSigned(req)
@@ -200,7 +202,10 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 }
 
 func (ip *IncomingPaymentService) Complete(ctx context.Context, params IncomingPaymentCompleteParams) (rs.IncomingPaymentWithMethods, error) {
-	fullURL := fmt.Sprintf("%s/complete", strings.TrimRight(params.URL, "/"))
+	fullURL, err := url.JoinPath(params.URL, "complete")
+	if err != nil {
+		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to construct URL: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, nil)
 	if err != nil {

--- a/outgoing_payment.go
+++ b/outgoing_payment.go
@@ -90,8 +90,11 @@ func (op *OutgoingPaymentService) List(ctx context.Context, params OutgoingPayme
 		query.Set("cursor", params.Pagination.Cursor)
 	}
 
-	base := strings.TrimRight(params.BaseURL, "/")
-	fullURL := fmt.Sprintf("%s/outgoing-payments?%s", base, query.Encode())
+	base, err := url.JoinPath(params.BaseURL, "outgoing-payments")
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct URL: %w", err)
+	}
+	fullURL := fmt.Sprintf("%s?%s", base, query.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
 	if err != nil {
@@ -130,15 +133,16 @@ func (op *OutgoingPaymentService) Create(ctx context.Context, params OutgoingPay
 		return rs.OutgoingPayment{}, fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	baseURL := strings.TrimRight(params.BaseURL, "/")
-	fullURL := fmt.Sprintf("%s/outgoing-payments", baseURL)
+	fullURL, err := url.JoinPath(params.BaseURL, "outgoing-payments")
+	if err != nil {
+		return rs.OutgoingPayment{}, fmt.Errorf("failed to construct URL: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return rs.OutgoingPayment{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("GNAP %s", params.AccessToken))
 
 	resp, err := op.DoSigned(req)

--- a/quote.go
+++ b/quote.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
+	"net/url"
 
 	rs "github.com/interledger/open-payments-go/generated/resourceserver"
 )
@@ -29,7 +29,7 @@ type QuoteCreateParams struct {
 	Payload any
 }
 
-func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quote, error) {
+func (qs *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quote, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, params.URL, nil)
 	if err != nil {
 		return rs.Quote{}, err
@@ -37,7 +37,7 @@ func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 
 	req.Header.Set("Authorization", fmt.Sprintf("GNAP %s", params.AccessToken))
 
-	resp, err := ip.DoSigned(req)
+	resp, err := qs.DoSigned(req)
 	if err != nil {
 		return rs.Quote{}, err
 	}
@@ -56,24 +56,25 @@ func (ip *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 	return quote, nil
 }
 
-func (ip *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (rs.Quote, error) {
+func (qs *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (rs.Quote, error) {
 	payloadBytes, err := json.Marshal(params.Payload)
 	if err != nil {
 		return rs.Quote{}, fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	baseURL := strings.TrimRight(params.BaseURL, "/")
-	fullURL := fmt.Sprintf("%s/quotes", baseURL)
+	fullURL, err := url.JoinPath(params.BaseURL, "quotes")
+	if err != nil {
+		return rs.Quote{}, fmt.Errorf("failed to construct URL: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return rs.Quote{}, err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("GNAP %s", params.AccessToken))
 
-	resp, err := ip.DoSigned(req)
+	resp, err := qs.DoSigned(req)
 	if err != nil {
 		return rs.Quote{}, err
 	}


### PR DESCRIPTION
## Summary

- [x] use url.joinPath to ensure trailing slash (as opposed to formatting or conditional append)
- [x] move content-type header to be set in DoSigned if there is a body (rather than explicitly adding in each method)
- [x] remove `CreateHeaders` and Use `CreateContentHeaders` + `CreateSignatureHeaders`, the request header mutation only occurs within `DoSigned`
- [x] fix vulnerability check CI 


Closes https://github.com/interledger/open-payments-go/issues/21