### PR TITLE
feat: add structured OpenPaymentsClientErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Requires:**
 
-- go1.21+
+- go1.22+
 
 ## OpenAPI Specs
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,57 @@
+package openpayments
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type OpenPaymentsClientError struct {
+	Description      string
+	Status           int
+	Code             string
+	ValidationErrors []string
+	Details          map[string]any
+	Method           string
+	URL              string
+}
+
+func (e *OpenPaymentsClientError) Error() string {
+	if e.Status != 0 {
+		return fmt.Sprintf("Error making Open Payments %s request to %s: %d %s",
+			e.Method, e.URL, e.Status, e.Description)
+	}
+	return fmt.Sprintf("Error making Open Payments %s request to %s: %s",
+		e.Method, e.URL, e.Description)
+}
+
+func newClientErrorFromResponse(req *http.Request, resp *http.Response) *OpenPaymentsClientError {
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	e := &OpenPaymentsClientError{
+		Status: resp.StatusCode,
+		Method: req.Method,
+		URL:    req.URL.String(),
+	}
+
+	var envelope struct {
+		Error struct {
+			Description string         `json:"description"`
+			Code        string         `json:"code"`
+			Details     map[string]any `json:"details"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(bodyBytes, &envelope); err == nil && envelope.Error.Description != "" {
+		e.Description = envelope.Error.Description
+		e.Code = envelope.Error.Code
+		e.Details = envelope.Error.Details
+	} else if len(bodyBytes) > 0 {
+		e.Description = string(bodyBytes)
+	} else {
+		e.Description = resp.Status
+	}
+
+	return e
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,133 @@
+package openpayments
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewClientErrorFromResponse_JSONBody(t *testing.T) {
+	body := `{"error":{"description":"invalid grant","code":"invalid_client","details":{"field":"client_id"}}}`
+	req, _ := http.NewRequest(http.MethodPost, "https://auth.example.com/grant", nil)
+	resp := &http.Response{
+		StatusCode: 401,
+		Status:     "401 Unauthorized",
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	err := newClientErrorFromResponse(req, resp)
+
+	if err.Status != 401 {
+		t.Errorf("expected status 401, got %d", err.Status)
+	}
+	if err.Description != "invalid grant" {
+		t.Errorf("expected description 'invalid grant', got %q", err.Description)
+	}
+	if err.Code != "invalid_client" {
+		t.Errorf("expected code 'invalid_client', got %q", err.Code)
+	}
+	if err.Details["field"] != "client_id" {
+		t.Errorf("expected details.field 'client_id', got %v", err.Details["field"])
+	}
+	if err.Method != http.MethodPost {
+		t.Errorf("expected method POST, got %q", err.Method)
+	}
+	if err.URL != "https://auth.example.com/grant" {
+		t.Errorf("expected URL 'https://auth.example.com/grant', got %q", err.URL)
+	}
+}
+
+func TestNewClientErrorFromResponse_NonJSONBody(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://rs.example.com/payments", nil)
+	resp := &http.Response{
+		StatusCode: 500,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(strings.NewReader("something went wrong")),
+	}
+
+	err := newClientErrorFromResponse(req, resp)
+
+	if err.Status != 500 {
+		t.Errorf("expected status 500, got %d", err.Status)
+	}
+	if err.Description != "something went wrong" {
+		t.Errorf("expected raw body as description, got %q", err.Description)
+	}
+	if err.Code != "" {
+		t.Errorf("expected empty code, got %q", err.Code)
+	}
+}
+
+func TestNewClientErrorFromResponse_EmptyBody(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodDelete, "https://auth.example.com/token/123", nil)
+	resp := &http.Response{
+		StatusCode: 403,
+		Status:     "403 Forbidden",
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	err := newClientErrorFromResponse(req, resp)
+
+	if err.Status != 403 {
+		t.Errorf("expected status 403, got %d", err.Status)
+	}
+	if err.Description != "403 Forbidden" {
+		t.Errorf("expected status text as description, got %q", err.Description)
+	}
+}
+
+func TestOpenPaymentsClientError_ErrorString(t *testing.T) {
+	err := &OpenPaymentsClientError{
+		Description: "not found",
+		Status:      404,
+		Method:      "GET",
+		URL:         "https://example.com/payments/123",
+	}
+
+	expected := "Error making Open Payments GET request to https://example.com/payments/123: 404 not found"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestOpenPaymentsClientError_ErrorStringNoStatus(t *testing.T) {
+	err := &OpenPaymentsClientError{
+		Description: "validation failed",
+		Method:      "POST",
+		URL:         "https://example.com/payments",
+	}
+
+	expected := "Error making Open Payments POST request to https://example.com/payments: validation failed"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestOpenPaymentsClientError_ErrorsAs(t *testing.T) {
+	origErr := newClientErrorFromResponse(
+		func() *http.Request {
+			r, _ := http.NewRequest(http.MethodGet, "https://example.com/test", nil)
+			return r
+		}(),
+		&http.Response{
+			StatusCode: 401,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"description":"unauthorized","code":"invalid_token"}}`)),
+		},
+	)
+
+	var wrapped error = origErr
+
+	var clientErr *OpenPaymentsClientError
+	if !errors.As(wrapped, &clientErr) {
+		t.Fatal("expected errors.As to match *OpenPaymentsClientError")
+	}
+	if clientErr.Status != 401 {
+		t.Errorf("expected status 401, got %d", clientErr.Status)
+	}
+	if clientErr.Code != "invalid_token" {
+		t.Errorf("expected code 'invalid_token', got %q", clientErr.Code)
+	}
+}

--- a/grant.go
+++ b/grant.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -82,13 +81,7 @@ func (gs *GrantService) Request(ctx context.Context, params GrantRequestParams) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		bodyStr := strings.TrimSpace(string(bodyBytes))
-
-		return Grant{}, fmt.Errorf(
-			"failed to perform grant request: %s\nURL: %s\nRequest body: %s\nResponse body: %s",
-			resp.Status, req.URL, string(reqBodyBytes), bodyStr,
-		)
+		return Grant{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var grantResponse Grant
@@ -133,7 +126,7 @@ func (gs *GrantService) Continue(ctx context.Context, params GrantContinueParams
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return Grant{}, fmt.Errorf("continue request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return Grant{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var grantResponse Grant
@@ -162,7 +155,7 @@ func (gs *GrantService) Cancel(ctx context.Context, params GrantCancelParams) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("cancel request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return newClientErrorFromResponse(req, resp)
 	}
 
 	return nil

--- a/incoming_payment.go
+++ b/incoming_payment.go
@@ -79,13 +79,13 @@ func getPublic(ctx context.Context, doUnsigned RequestDoer, url string) (rs.Publ
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.PublicIncomingPayment{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var incomingPayment rs.PublicIncomingPayment
 	err = json.NewDecoder(resp.Body).Decode(&incomingPayment)
 	if err != nil {
-		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.PublicIncomingPayment{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return incomingPayment, nil
@@ -106,13 +106,13 @@ func (ip *IncomingPaymentService) Get(ctx context.Context, params IncomingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
 	err = json.NewDecoder(resp.Body).Decode(&incomingPayment)
 	if err != nil {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return incomingPayment, nil
@@ -151,7 +151,7 @@ func (ip *IncomingPaymentService) List(ctx context.Context, params IncomingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get incoming payment: %s", resp.Status)
+		return nil, newClientErrorFromResponse(req, resp)
 	}
 
 	var listResponse IncomingPaymentListResponse
@@ -189,7 +189,7 @@ func (ip *IncomingPaymentService) Create(ctx context.Context, params IncomingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to create incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var incomingPayment rs.IncomingPaymentWithMethods
@@ -221,7 +221,7 @@ func (ip *IncomingPaymentService) Complete(ctx context.Context, params IncomingP
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.IncomingPaymentWithMethods{}, fmt.Errorf("failed to complete incoming payment: %s", resp.Status)
+		return rs.IncomingPaymentWithMethods{}, newClientErrorFromResponse(req, resp)
 	}
 
 	// TODO: add the validation like TS? php/rust. Not sure if we should on principle.

--- a/outgoing_payment.go
+++ b/outgoing_payment.go
@@ -61,7 +61,7 @@ func (op *OutgoingPaymentService) Get(ctx context.Context, params OutgoingPaymen
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to get outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var outgoingPayment rs.OutgoingPayment
@@ -110,7 +110,7 @@ func (op *OutgoingPaymentService) List(ctx context.Context, params OutgoingPayme
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list outgoing payments: %s", resp.Status)
+		return nil, newClientErrorFromResponse(req, resp)
 	}
 
 	var listResponse OutgoingPaymentListResponse
@@ -152,7 +152,7 @@ func (op *OutgoingPaymentService) Create(ctx context.Context, params OutgoingPay
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.OutgoingPayment{}, fmt.Errorf("failed to create outgoing payment: %s", resp.Status)
+		return rs.OutgoingPayment{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var outgoingPayment rs.OutgoingPayment

--- a/quote.go
+++ b/quote.go
@@ -44,13 +44,13 @@ func (qs *QuoteService) Get(ctx context.Context, params QuoteGetParams) (rs.Quot
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rs.Quote{}, fmt.Errorf("failed to get quote: %s", resp.Status)
+		return rs.Quote{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var quote rs.Quote
 	err = json.NewDecoder(resp.Body).Decode(&quote)
 	if err != nil {
-		return rs.Quote{}, fmt.Errorf("failed to decode response body: %s", err)
+		return rs.Quote{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return quote, nil
@@ -81,7 +81,7 @@ func (qs *QuoteService) Create(ctx context.Context, params QuoteCreateParams) (r
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return rs.Quote{}, fmt.Errorf("failed to create quote: %s", resp.Status)
+		return rs.Quote{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var quote rs.Quote

--- a/token.go
+++ b/token.go
@@ -46,7 +46,7 @@ func (ts *TokenService) Rotate(ctx context.Context, params TokenRotateParams) (a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as.AccessToken{}, fmt.Errorf("rotate request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return as.AccessToken{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var response struct {
@@ -78,7 +78,7 @@ func (ts *TokenService) Revoke(ctx context.Context, params TokenRevokeParams) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("revoke request failed with status %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return newClientErrorFromResponse(req, resp)
 	}
 
 	return nil

--- a/wallet_address.go
+++ b/wallet_address.go
@@ -37,13 +37,13 @@ func (wa *WalletAddressService) Get(ctx context.Context, params WalletAddressGet
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.WalletAddress{}, fmt.Errorf("failed to get wallet address: %s", resp.Status)
+		return was.WalletAddress{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var walletAddressResponse was.WalletAddress
 	err = json.NewDecoder(resp.Body).Decode(&walletAddressResponse)
 	if err != nil {
-		return was.WalletAddress{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.WalletAddress{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return walletAddressResponse, nil
@@ -64,13 +64,13 @@ func (wa *WalletAddressService) GetKeys(ctx context.Context, params WalletAddres
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.JsonWebKeySet{}, fmt.Errorf("failed to get json web keys: %s", resp.Status)
+		return was.JsonWebKeySet{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var keyResponse was.JsonWebKeySet
 	err = json.NewDecoder(resp.Body).Decode(&keyResponse)
 	if err != nil {
-		return was.JsonWebKeySet{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.JsonWebKeySet{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return keyResponse, nil
@@ -91,13 +91,13 @@ func (wa *WalletAddressService) GetDIDDocument(ctx context.Context, params Walle
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return was.DidDocument{}, fmt.Errorf("failed to get DID document: %s", resp.Status)
+		return was.DidDocument{}, newClientErrorFromResponse(req, resp)
 	}
 
 	var DIDDocumentResponse was.DidDocument
 	err = json.NewDecoder(resp.Body).Decode(&DIDDocumentResponse)
 	if err != nil {
-		return was.DidDocument{}, fmt.Errorf("failed to decoding response body: %s", err)
+		return was.DidDocument{}, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return DIDDocumentResponse, nil


### PR DESCRIPTION
## Summary

- Add `OpenPaymentsClientError` type mirroring the open-payments-node sdk's `OpenPaymentsClientError` class 
   - Supersede https://github.com/interledger/open-payments-go/pull/42
   - Supersede https://github.com/interledger/open-payments-go/pull/39
- Add `newClientErrorFromResponse()` function that parses the error from API responses
- Replace all `fmt.Errorf` HTTP error handling with the OpenPaymentsClientError
- Fix inconsistent %s → %w error wrapping for JSON decode errors 
  - Supersede https://github.com/interledger/open-payments-go/pull/40


Closes https://github.com/interledger/open-payments-go/issues/15