### PR TITLE
feat: Support key derivation from file, base64 and raw format

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,7 @@ func NewAuthenticatedClient(walletAddressUrl string, privateKey string, keyId st
 		return nil, fmt.Errorf("invalid wallet address: %q (cannot start with '$')", walletAddressUrl)
 	}
 
-	edKey, err := httpsignatureutils.LoadBase64Key(privateKey)
+	edKey, err := httpsignatureutils.LoadKey(privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("error loading private key: %w", err)
 	}

--- a/httpsignatureutils/key.go
+++ b/httpsignatureutils/key.go
@@ -38,7 +38,7 @@ func LoadBase64Key(base64Key string) (ed25519.PrivateKey, error) {
 }
 
 func LoadKeyFromFile(path string) (ed25519.PrivateKey, error) {
-	fileBytes, err := os.ReadFile(path)
+	fileBytes, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return nil, fmt.Errorf("could not load file: %w", err)
 	}

--- a/httpsignatureutils/key.go
+++ b/httpsignatureutils/key.go
@@ -6,14 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"os"
+	"strings"
 )
 
-func LoadBase64Key(base64Key string) (ed25519.PrivateKey, error) {
-	pemBytes, err := base64.StdEncoding.DecodeString(base64Key)
-	if err != nil {
-		return nil, fmt.Errorf("invalid base64: %w", err)
-	}
-
+func parseEd25519PEM(pemBytes []byte) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, fmt.Errorf("failed to parse PEM block")
@@ -29,4 +26,41 @@ func LoadBase64Key(base64Key string) (ed25519.PrivateKey, error) {
 	} else {
 		return nil, fmt.Errorf("key is not an Ed25519 key")
 	}
+}
+
+func LoadBase64Key(base64Key string) (ed25519.PrivateKey, error) {
+	pemBytes, err := base64.StdEncoding.DecodeString(base64Key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64: %w", err)
+	}
+
+	return parseEd25519PEM(pemBytes)
+}
+
+func LoadKeyFromFile(path string) (ed25519.PrivateKey, error) {
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not load file: %w", err)
+	}
+
+	return parseEd25519PEM(fileBytes)
+}
+
+func LoadPEMKey(pemString string) (ed25519.PrivateKey, error) {
+	return parseEd25519PEM([]byte(pemString))
+}
+
+func LoadKey(input string) (ed25519.PrivateKey, error) {
+	// PEM file path
+	if _, err := os.Stat(input); err == nil {
+		return LoadKeyFromFile(input)
+	}
+
+	// Raw PEM string
+	if strings.HasPrefix(strings.TrimSpace(input), "-----BEGIN") {
+		return LoadPEMKey(input)
+	}
+
+	// Base64 Key
+	return LoadBase64Key(input)
 }


### PR DESCRIPTION
## Summary
- Add `LoadKey` function that accepts a file path, raw PEM string, or base64-encoded PEM string similar to the pattern [node sdk](https://github.com/interledger/open-payments-node/blob/main/packages/http-signature-utils/src/utils/key.ts#L11) follows

Closes #16